### PR TITLE
Potential fix for code scanning alert no. 1: Missing rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,8 @@
     "wouter": "^3.3.5",
     "ws": "^8.18.0",
     "zod": "^3.24.2",
-    "zod-validation-error": "^3.4.0"
+    "zod-validation-error": "^3.4.0",
+    "express-rate-limit": "^8.1.0"
   },
   "devDependencies": {
     "@replit/vite-plugin-cartographer": "^0.3.0",

--- a/server/vite.ts
+++ b/server/vite.ts
@@ -5,7 +5,7 @@ import { createServer as createViteServer, createLogger } from "vite";
 import { type Server } from "http";
 import viteConfig from "../vite.config";
 import { nanoid } from "nanoid";
-
+import rateLimit from "express-rate-limit";
 const viteLogger = createLogger();
 
 export function log(message: string, source = "express") {
@@ -41,6 +41,14 @@ export async function setupVite(app: Express, server: Server) {
   });
 
   app.use(vite.middlewares);
+
+  // Apply rate limiting to all client-side requests that use the filesystem
+  const limiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100, // limit each IP to 100 requests per windowMs
+  });
+  app.use(limiter);
+
   app.use("*", async (req, res, next) => {
     const url = req.originalUrl;
 

--- a/server/vite.ts
+++ b/server/vite.ts
@@ -47,9 +47,9 @@ export async function setupVite(app: Express, server: Server) {
     windowMs: 60 * 1000, // 1 minute
     max: 1000, // limit each IP to 1000 requests per windowMs
   });
-  app.use(limiter);
+  // app.use(limiter);
 
-  app.use("*", async (req, res, next) => {
+  app.use("*", limiter, async (req, res, next) => {
     const url = req.originalUrl;
 
     try {

--- a/server/vite.ts
+++ b/server/vite.ts
@@ -44,8 +44,8 @@ export async function setupVite(app: Express, server: Server) {
 
   // Apply rate limiting to all client-side requests that use the filesystem
   const limiter = rateLimit({
-    windowMs: 15 * 60 * 1000, // 15 minutes
-    max: 100, // limit each IP to 100 requests per windowMs
+    windowMs: 60 * 1000, // 1 minute
+    max: 1000, // limit each IP to 1000 requests per windowMs
   });
   app.use(limiter);
 


### PR DESCRIPTION
Potential fix for [https://github.com/canstralian/BerylManager/security/code-scanning/1](https://github.com/canstralian/BerylManager/security/code-scanning/1)

To fix the problem, we need to apply a rate-limiting middleware to all routes or, at a minimum, the `"*"` catch-all route that performs the file system read. The standard approach in Express is to use the `express-rate-limit` package, which lets us set limits on the frequency of requests from the same client.  

Specifically:
- Add the `express-rate-limit` dependency to the project.
- Add an import for `express-rate-limit` in `server/vite.ts`.
- Create a limiter middleware specifying reasonable thresholds (e.g., 100 requests per 15 minutes).
- Apply this limiter before the `"*"` route handler at line 44, by using `app.use(limiter)` above `app.use("*", ...)`.

No other changes are needed, as the logic of the handler itself does not need altering.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
